### PR TITLE
improve: support for replicaCount and enable rollout strategy

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     {{- include "airbyte-keycloak.labels" . | nindent 4 }}
 spec:
+  replicas: {{ .Values.replicaCount | default 2 }}
+  podManagementPolicy: OrderedReady # embedded infinispan does not handle parallel joins well, src https://github.com/keycloak/keycloak/issues/21108#issuecomment-1599010602
+  updateStrategy:
+    type: RollingUpdate
   selector:
     matchLabels:
       {{- include "airbyte-keycloak.selectorLabels" . | nindent 6 }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,5 +1,7 @@
 # Default values for keycloak.
 
+replicaCount: ""
+
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
   repository: airbyte/keycloak


### PR DESCRIPTION
These configs were not ported over from the old chart, so this brings us inline with how we were configuring Keycloak in production.

There is an accompanying PR that sets the replica count:
https://github.com/airbytehq/gitops/pull/144
